### PR TITLE
Voiced statistics model rework

### DIFF
--- a/src/ESPER/components.c
+++ b/src/ESPER/components.c
@@ -201,7 +201,7 @@ void weightedDistance(fftw_complex point, fftw_complex mean, float variance, flo
 void separateVoicedUnvoicedPostProc(fftw_complex* dftCoeffs, cSample sample, engineCfg config)
 {
     int effectiveLength = sample.config.markerLength - 1;
-    int kernelSize = 12;
+    int kernelSize = 10;
     fftw_complex* smoothedDftCoeffs = (fftw_complex*)malloc(effectiveLength * config.halfHarmonics * sizeof(fftw_complex));
     float* leftSum = (float*)malloc(2 * config.halfHarmonics * sizeof(float));
     float* rightSum = (float*)malloc(2 * config.halfHarmonics * sizeof(float));

--- a/src/ESPER/components.c
+++ b/src/ESPER/components.c
@@ -180,7 +180,7 @@ float squaredDistance_cpx(fftw_complex cpx1, fftw_complex cpx2)
 void separateVoicedUnvoicedPostProc(fftw_complex* dftCoeffs, cSample sample, engineCfg config)
 {
     int effectiveLength = sample.config.markerLength - 1;
-    int kernelSize = 24;
+    int kernelSize = 12;
     fftw_complex* smoothedDftCoeffs = (fftw_complex*)malloc(effectiveLength * config.halfHarmonics * sizeof(fftw_complex));
     for (int i = 0; i < effectiveLength; i++)
     {
@@ -192,9 +192,9 @@ void separateVoicedUnvoicedPostProc(fftw_complex* dftCoeffs, cSample sample, eng
             {
                 index = 0;
             }
-            else if (index >= effectiveLength)
+            else if (index > effectiveLength - kernelSize)
             {
-                index = effectiveLength - 1;
+                index = effectiveLength - kernelSize;
             }
             fftw_complex* window = dftCoeffs + index * config.halfHarmonics;
             //initialize required variables
@@ -226,12 +226,21 @@ void separateVoicedUnvoicedPostProc(fftw_complex* dftCoeffs, cSample sample, eng
             //calculate mean of the side containing the window center
 			(*(smoothedDftCoeffs + i * config.halfHarmonics + j))[0] = 0.;
 			(*(smoothedDftCoeffs + i * config.halfHarmonics + j))[1] = 0.;
+
+            /*for (int k = 0; k < kernelSize; k++)
+            {
+                (*(smoothedDftCoeffs + i * config.halfHarmonics + j))[0] += (*(window + j + config.halfHarmonics * k))[0];
+                (*(smoothedDftCoeffs + i * config.halfHarmonics + j))[1] += (*(window + j + config.halfHarmonics * k))[1];
+            }
+            (*(smoothedDftCoeffs + i * config.halfHarmonics + j))[0] /= kernelSize;
+            (*(smoothedDftCoeffs + i * config.halfHarmonics + j))[1] /= kernelSize;*/
+
             if (jumpPoint < kernelSize / 2)
             {
 				for (int k = 0; k < jumpPoint; k++)
 				{
-					(*(smoothedDftCoeffs + i * config.halfHarmonics + j))[0] += (*(window + k))[0];
-					(*(smoothedDftCoeffs + i * config.halfHarmonics + j))[1] += (*(window + k))[1];
+					(*(smoothedDftCoeffs + i * config.halfHarmonics + j))[0] += (*(window + j + config.halfHarmonics * k))[0];
+					(*(smoothedDftCoeffs + i * config.halfHarmonics + j))[1] += (*(window + j + config.halfHarmonics * k))[1];
 				}
 				(*(smoothedDftCoeffs + i * config.halfHarmonics + j))[0] /= jumpPoint;
 				(*(smoothedDftCoeffs + i * config.halfHarmonics + j))[1] /= jumpPoint;
@@ -240,8 +249,8 @@ void separateVoicedUnvoicedPostProc(fftw_complex* dftCoeffs, cSample sample, eng
             {
                 for (int k = jumpPoint; k < kernelSize; k++)
                 {
-                    (*(smoothedDftCoeffs + i * config.halfHarmonics + j))[0] += (*(window + k))[0];
-                    (*(smoothedDftCoeffs + i * config.halfHarmonics + j))[1] += (*(window + k))[1];
+                    (*(smoothedDftCoeffs + i * config.halfHarmonics + j))[0] += (*(window + j + config.halfHarmonics * k))[0];
+                    (*(smoothedDftCoeffs + i * config.halfHarmonics + j))[1] += (*(window + j + config.halfHarmonics * k))[1];
                 }
 				(*(smoothedDftCoeffs + i * config.halfHarmonics + j))[0] /= kernelSize - jumpPoint;
 				(*(smoothedDftCoeffs + i * config.halfHarmonics + j))[1] /= kernelSize - jumpPoint;

--- a/src/ESPER/esper.c
+++ b/src/ESPER/esper.c
@@ -17,7 +17,7 @@ void LIBESPER_CDECL specCalc(cSample sample, engineCfg config)
 {
     sample.config.batches = sample.config.length / config.batchSize;
     separateVoicedUnvoiced(sample, config);
-    smoothFourierSpace(sample, config);
-	smoothTempSpace(sample, config);
+    //smoothFourierSpace(sample, config);
+	//smoothTempSpace(sample, config);
     finalizeSample(sample, config);
 }

--- a/src/ESPER/esper.c
+++ b/src/ESPER/esper.c
@@ -17,7 +17,7 @@ void LIBESPER_CDECL specCalc(cSample sample, engineCfg config)
 {
     sample.config.batches = sample.config.length / config.batchSize;
     separateVoicedUnvoiced(sample, config);
-    //smoothFourierSpace(sample, config);
-	//smoothTempSpace(sample, config);
+    smoothFourierSpace(sample, config);
+	smoothTempSpace(sample, config);
     finalizeSample(sample, config);
 }

--- a/src/ESPER/pitchCalcFallback.c
+++ b/src/ESPER/pitchCalcFallback.c
@@ -245,7 +245,7 @@ void checkMarkerValidity(cSample* sample, engineCfg config)
 		float invalidError = 0.;
 		for (int j = 0; j < sectionSize; j++)
 		{
-			float alternative = *(sample->waveform + *(sample->pitchMarkers + i - 1) + j) + (*(sample->waveform + *(sample->pitchMarkers + i + 2) - sectionSize + j));
+			float alternative = *(sample->waveform + *(sample->pitchMarkers + i - 1) + j) - (*(sample->waveform + *(sample->pitchMarkers + i + 2) - sectionSize + j));
 			invalidError += powf(alternative / 2., 2.);
 		}
 		if (invalidError < validError)

--- a/src/Renderer/modifiers.c
+++ b/src/Renderer/modifiers.c
@@ -101,7 +101,7 @@ void LIBESPER_CDECL pitchShift(float* specharm, float* srcPitch, float* tgtPitch
 				*(tgtSpace + j) = config.halfTripleBatchSize;
 			}
 			*(srcVals + j) = *(specharm + i * config.frameSize + j);
-			srcAmplitude += powf(*(srcVals + j), 2.);
+			srcAmplitude += *(srcVals + j);
 		}
 		for (int j = config.halfHarmonics; j < srcSize; j++)
 		{
@@ -112,15 +112,12 @@ void LIBESPER_CDECL pitchShift(float* specharm, float* srcPitch, float* tgtPitch
 		for (int j = 0; j < config.halfHarmonics; j++)
 		{
 			*(specharm + i * config.frameSize + j) = *(tgtVals + j);
-			tgtAmplitude += powf(*(tgtVals + j), 2.);
+			tgtAmplitude += *(tgtVals + j);
 		}
 		free(tgtVals);
-		if (srcAmplitude < tgtAmplitude && tgtAmplitude > 0.)
+		for (int j = 0; j < config.halfHarmonics; j++)
 		{
-			for (int j = 0; j < config.halfHarmonics; j++)
-			{
-				*(specharm + i * config.frameSize + j) *= srcAmplitude / tgtAmplitude;
-			}
+			*(specharm + i * config.frameSize + j) *= sqrtf(srcAmplitude / tgtAmplitude);
 		}
 		float modEffTgtPitch;
 		if (*(breathiness + i) > 0.)
@@ -141,7 +138,7 @@ void LIBESPER_CDECL pitchShift(float* specharm, float* srcPitch, float* tgtPitch
 			{
 				*(shiftedSpectrumSpace + j) = config.halfTripleBatchSize;
 			}
-			srcAmplitude += powf(*(specharm + i * config.frameSize + config.nHarmonics + 2 + j), 2.);
+			srcAmplitude += *(specharm + i * config.frameSize + config.nHarmonics + 2 + j);
 		}
 		float* multipliers = interp(
 			spectrumSpace,
@@ -153,14 +150,14 @@ void LIBESPER_CDECL pitchShift(float* specharm, float* srcPitch, float* tgtPitch
 		for (int j = 0; j < config.halfTripleBatchSize + 1; j++)
 		{
 			*(specharm + i * config.frameSize + config.nHarmonics + 2 + j) = *(multipliers + j);
-			tgtAmplitude += powf(*(specharm + i * config.frameSize + config.nHarmonics + 2 + j), 2.);
+			tgtAmplitude += *(specharm + i * config.frameSize + config.nHarmonics + 2 + j);
 		}
 		free(multipliers);
 		if (srcAmplitude < tgtAmplitude && tgtAmplitude > 0.)
 		{
 			for (int j = 0; j < config.halfTripleBatchSize + 1; j++)
 			{
-				*(specharm + i * config.frameSize + config.nHarmonics + 2 + j) *= srcAmplitude / tgtAmplitude;
+				*(specharm + i * config.frameSize + config.nHarmonics + 2 + j) *= sqrtf(srcAmplitude / tgtAmplitude);
 			}
 		}
 	}


### PR DESCRIPTION
This pull request mainly includes a new statistical model for voiced speech. In now includes a dynamically placed "jump point", where it is assumed the speech abruptly changes to a different phoneme, in each window. This should reduce artifacting near phoneme transitions compared to the old method of assuming the characteristics of the voiced part stay constant within each window.

Additionally, several more minor tweaks and fixes are included, particularly to audio normalization during pitch shifting.